### PR TITLE
Added webclient hardware keyboard support

### DIFF
--- a/app/views/webclient_video.server.view.html
+++ b/app/views/webclient_video.server.view.html
@@ -9,11 +9,11 @@
 <body>
 <div id="content">
     <table style="margin-left:auto; margin-right:auto; text-align:center">
-        <tr><td>
+        <tr><td colspan="2">
             <video id="rtcvidstream" class="hide" autoplay></video>
             <canvas id="touchcanvas" class="hide" style="border:2px solid black"></canvas>
         </td></tr>
-        <tr><td>
+        <tr><td colspan="2">
             <div class="btn-group btn-group-justified btn-group-lg" style="table-layout:auto">
                 <a href="#" id="backButton" class="btn btn-default" style="width:33.3%" title="Back">
                     <span class="glyphicon glyphicon-chevron-left"></span>
@@ -27,6 +27,11 @@
             </div>
         </td></tr>
         <tr><td>
+            <br />
+            <label class="btn btn-toggle" for="keyboard-toggle">
+                <input type="checkbox" id="keyboard-toggle" />Soft Keyboard
+            </label>
+            </td><td>
             <br />
             <button id="logoutButton" type="button" class="btn btn-lg btn-danger">Log Out</button>
         </td></tr>
@@ -142,48 +147,30 @@
     canvas.addEventListener("mousemove", function(ev) { handleMouseMove(ev, ws, svmp) }, false);
     canvas.addEventListener("mouseout", function(ev) { handleMouseEnd(ev, ws, svmp) }, false);
 
+    // capture keyboard events
+    $(document).keydown(function(event) {
+        // keydown, NOT keypress, there is a difference
+        handleKeyDown(event, ws, svmp);
+    });
+    $(document).keyup(function(event) {
+        handleKeyUp(event, ws, svmp);
+    });
+
     // set up Android button listeners
     $("#backButton").click(function() {
-        androidButton(4);
+        androidKeyDownUp(4, ws, svmp);
     });
     $("#homeButton").click(function() {
-        androidButton(3);
+        androidKeyDownUp(3, ws, svmp);
     });
     $("#appSwitchButton").click(function() {
-        androidButton(187);
+        androidKeyDownUp(187, ws, svmp);
     });
-    function androidButton(buttonCode) {
-        if (window.svmpState !== "running")
-            return;
-        var buttonRequest = new svmp.Request({
-            type: svmp.Request.RequestType.KEYEVENT,
-            key: {
-                eventTime: {
-                    low: 0,
-                    high: 0,
-                    unsigned: false
-                },
-                deviceId: 2,
-                flags: 72,
-                downTime: {
-                    low: 0,
-                    high: 0,
-                    unsigned: false
-                },
-                action: 0,
-                code: buttonCode,
-                repeat: 0,
-                metaState: 0,
-                scanCode: 158,
-                source: 257
-            }
-        });
-        // send button down
-        window.socket.send(buttonRequest.encodeDelimited().toArrayBuffer());
-        // send button up
-        buttonRequest.key.action = 1;
-        window.socket.send(buttonRequest.encodeDelimited().toArrayBuffer());
-    }
+
+    // soft keyboard button listener
+    $("#keyboard-toggle").click(function() {
+        sendKeyboardConfig(this.checked, ws, svmp);
+    });
 </script>
 
 </body>

--- a/public/js/webclient/handlers.js
+++ b/public/js/webclient/handlers.js
@@ -118,9 +118,9 @@ function sendInitRequests(socket, pbuf) {
     sinfo = new pbuf.Request({"type" : pbuf.Request.RequestType.SCREENINFO});
     socket.send(sinfo.encodeDelimited().toArrayBuffer());
 
-    // send CONFIG request
-    sinfo = new pbuf.Request({"type" : pbuf.Request.RequestType.CONFIG, "config": {"hardKeyboard": false}});
-    socket.send(sinfo.encodeDelimited().toArrayBuffer());
+    // send CONFIG request (disables software keyboard on VM)
+    var softKeyboard = false;
+    sendKeyboardConfig(softKeyboard, socket, pbuf);
 
     // send APPS request
     sinfo = new pbuf.Request({"type" : pbuf.Request.RequestType.APPS, "apps": {"type": pbuf.AppsRequest.AppsRequestType.LAUNCH}});
@@ -209,7 +209,9 @@ function handleResponseRunning(resp, socket, pbuf) {
             break;
         case pbuf.Response.ResponseType.NOTIFICATION:
             console.log("Received NOTIFICATION");
-            alert(resp.notification.contentTitle + "\n" + resp.notification.contentText);
+            if (resp.notification.contentTitle !== "Select keyboard layout")
+                // we don't want to pass along this keyboard layout notification...
+                alert(resp.notification.contentTitle + "\n" + resp.notification.contentText);
             break;
         case pbuf.Response.ResponseType.LOCATION:
             switch(resp.locationResponse.type) {
@@ -396,4 +398,200 @@ function handleRotation(ev, socket, pbuf) {
     }
     var cont = new pbuf.Request({"type" : pbuf.Request.RequestType.ROTATION_INFO, "rotationInfo" : new pbuf.RotationInfo({"rotation" : window.rotation})});
     socket.send(cont.encodeDelimited().toArrayBuffer());
+}
+
+/***************************************************************
+*                       KEYBOARD SUPPORT                       *
+***************************************************************/
+
+// toggles the software keyboard on the VM on or off
+function sendKeyboardConfig(softKeyboard, ws, svmp) {
+    var configRequest = new svmp.Request({"type" : svmp.Request.RequestType.CONFIG, "config": {"hardKeyboard": !softKeyboard}});
+    ws.send(configRequest.encodeDelimited().toArrayBuffer());
+}
+
+// event handler for DOM
+function handleKeyDown(ev, ws, svmp) {
+    // translate ASCII key code to Android key code
+    var keyCode = translateKeyCode(ev.which);
+
+    // if it's a modifier key, change the state machine
+    modifierKeyState(keyCode, true);
+
+    // if the key code was valid, send it over the wire
+    if (keyCode >= 0) {
+        ev.preventDefault(); // prevent default behavior for this key press
+        androidKeyDown(keyCode, ws, svmp); // send the key code to the VM
+    }
+}
+
+// event handler for DOM
+function handleKeyUp(ev, ws, svmp) {
+    // translate ASCII key code to Android key code
+    var keyCode = translateKeyCode(ev.which);
+
+    // if it's a modifier key, change the state machine
+    modifierKeyState(keyCode, false);
+
+    // if the key code was valid,
+    if (keyCode >= 0) {
+        ev.preventDefault(); // prevent default behavior for this key press
+        androidKeyUp(keyCode, ws, svmp); // send the key code to the VM
+    }
+}
+
+// basic state machine for modifier keys
+function modifierKeyState(keyCode, isDown) {
+    // (this will break if, for instance, both shifts are pressed down and one is let up)
+    if (keyCode === SHIFT)
+        SHIFT_DOWN = isDown;
+    else if (keyCode === CTRL)
+        CTRL_DOWN = isDown;
+    else if (keyCode === ALT)
+        ALT_DOWN = isDown;
+}
+
+// android modifier key codes
+var SHIFT = 59;
+var CTRL = 113;
+var ALT = 57;
+
+// modifier key states
+var SHIFT_DOWN = false;
+var CTRL_DOWN = false;
+var ALT_DOWN = false;
+
+// arguments to create a button request
+var buttonRequestArg = {
+    eventTime: {
+        low: 0,
+        high: 0,
+        unsigned: false
+    },
+    deviceId: 2,
+    flags: 72,
+    downTime: {
+        low: 0,
+        high: 0,
+        unsigned: false
+    },
+    action: 0,
+    repeat: 0,
+    metaState: 0,
+    scanCode: 158,
+    source: 257
+};
+
+// used for buttons (Back, Home, App Switch)
+// sends key down event, and immediately sends key up event
+function androidKeyDownUp(buttonCode, ws, svmp) {
+    androidKeyDown(buttonCode, ws, svmp, true);
+    androidKeyUp(buttonCode, ws, svmp, true);
+}
+
+// sends a key down event to the VM
+function androidKeyDown(buttonCode, ws, svmp, isButton) {
+    if (window.svmpState !== "running")
+        return;
+    var buttonRequest = new svmp.Request({type: svmp.Request.RequestType.KEYEVENT, key: buttonRequestArg});
+    buttonRequest.key.code = buttonCode;
+
+    // if this is not a button (it's a keyboard key), add any modifiers
+    if (!isButton)
+        addMetaState(buttonRequest);
+
+    // send button down
+    ws.send(buttonRequest.encodeDelimited().toArrayBuffer());
+}
+
+// sends a key up event to the VM
+function androidKeyUp(buttonCode, ws, svmp, isButton) {
+    if (window.svmpState !== "running")
+        return;
+    var buttonRequest = new svmp.Request({type: svmp.Request.RequestType.KEYEVENT, key: buttonRequestArg});
+    buttonRequest.key.code = buttonCode;
+    buttonRequest.key.action = 1;
+
+    // if this is not a button (it's a keyboard key), add any modifiers
+    if (!isButton)
+        addMetaState(buttonRequest);
+
+    // send button up
+    ws.send(buttonRequest.encodeDelimited().toArrayBuffer());
+}
+
+function addMetaState(buttonRequest) {
+    var metaState = 0;
+    if (SHIFT_DOWN)
+        metaState += 65;
+    if (CTRL_DOWN)
+        metaState += 12288;
+    if (ALT_DOWN)
+        metaState += 18;
+    buttonRequest.key.metaState = metaState;
+}
+
+// translates from sane browser-generated ASCII key codes to incomprehensible Android key codes
+function translateKeyCode(which) {
+    var keyCode = -1;
+    if (which >= 48 && which <= 57)      // JS: 0-9
+        keyCode = which - 41;            // Android: 0-9
+    else if (which >= 65 && which <= 90) // JS: a-z
+        keyCode = which - 36;            // Android: a-z
+    else if (which == 192)               // JS: `
+        keyCode = 68;                    // Android: KEYCODE_GRAVE
+    else if (which == 9)                 // JS: tab
+        keyCode = 61;                    // Android: KEYCODE_TAB
+    else if (which == 16)                // JS: shift (there is no right/left shift in Javascript)
+        keyCode = SHIFT;                 // Android: KEYCODE_SHIFT_LEFT
+    else if (which == 17)                // JS: ctrl (there is no right/left ctrl in Javascript)
+        keyCode = CTRL;                  // Android: KEYCODE_CTRL_LEFT
+    else if (which == 18)                // JS: alt (there is no right/left alt in Javascript)
+        keyCode = ALT;                   // Android: KEYCODE_ALT_LEFT
+    else if (which == 32)                // JS: space
+        keyCode = 62;                    // Android: space
+    else if (which == 189)               // JS: -
+        keyCode = 69;                    // Android: KEYCODE_MINUS
+    else if (which == 187)               // JS: =
+        keyCode = 70;                    // Android: KEYCODE_EQUALS
+    else if (which == 8)                 // JS: backspace
+        keyCode = 67;                    // Android: KEYCODE_DEL
+    else if (which == 46)                // JS: delete
+        keyCode = 112;                   // Android: KEYCODE_FORWARD_DEL
+    else if (which == 219)               // JS: [
+        keyCode = 71;                    // Android: KEYCODE_LEFT_BRACKET
+    else if (which == 221)               // JS: ]
+        keyCode = 72;                    // Android: KEYCODE_RIGHT_BRACKET
+    else if (which == 220)               // JS: \
+        keyCode = 73;                    // Android: KEYCODE_BACKSLASH
+    else if (which == 186)               // JS: ;
+        keyCode = 74;                    // Android: KEYCODE_SEMICOLON
+    else if (which == 222)               // JS: '
+        keyCode = 75;                    // Android: KEYCODE_APOSTROPHE
+    else if (which == 13)                // JS: ;
+        keyCode = 66;                    // Android: KEYCODE_ENTER
+    else if (which == 188)               // JS: ,
+        keyCode = 55;                    // Android: KEYCODE_COMMA
+    else if (which == 190)               // JS: .
+        keyCode = 56;                    // Android: KEYCODE_PERIOD
+    else if (which == 191)               // JS: /
+        keyCode = 76;                    // Android: KEYCODE_SLASH
+    else if (which == 36)                // JS: home
+        keyCode = 122;                   // Android: KEYCODE_MOVE_HOME
+    else if (which == 35)                // JS: end
+        keyCode = 123;                   // Android: KEYCODE_MOVE_END
+    else if (which == 33)                // JS: page up
+        keyCode = 92;                    // Android: KEYCODE_PAGE_UP
+    else if (which == 34)                // JS: page down
+        keyCode = 93;                    // Android: KEYCODE_PAGE_DOWN
+    else if (which == 38)                // JS: up arrow
+        keyCode = 19;                    // Android: KEYCODE_DPAD_UP
+    else if (which == 37)                // JS: left arrow
+        keyCode = 21;                    // Android: KEYCODE_DPAD_LEFT
+    else if (which == 39)                // JS: right arrow
+        keyCode = 22;                    // Android: KEYCODE_DPAD_RIGHT
+    else if (which == 40)                // JS: down arrow
+        keyCode = 20;                    // Android: KEYCODE_DPAD_DOWN
+
+    return keyCode;
 }

--- a/public/js/webclient/handlers.js
+++ b/public/js/webclient/handlers.js
@@ -462,24 +462,26 @@ var CTRL_DOWN = false;
 var ALT_DOWN = false;
 
 // arguments to create a button request
+// when received by SVMPD, gets translated into a KeyEvent
+// see http://developer.android.com/reference/android/view/KeyEvent.html
 var buttonRequestArg = {
     eventTime: {
         low: 0,
         high: 0,
         unsigned: false
     },
-    deviceId: 2,
-    flags: 72,
+    deviceId: 2, // the id for the device that this came from; an id greater than zero is arbitrary
+    flags: 8, // KeyEvent.FLAG_FROM_SYSTEM
     downTime: {
         low: 0,
         high: 0,
         unsigned: false
     },
-    action: 0,
+    action: 0, // KeyEvent.ACTION_DOWN
     repeat: 0,
-    metaState: 0,
-    scanCode: 158,
-    source: 257
+    metaState: 0, // changes with Shift, Ctrl, and/or Alt
+    scanCode: 158, // stub; the hardware key id of this key event, these values are not reliable and vary from device to device
+    source: 257 // InputDevice.SOURCE_KEYBOARD
 };
 
 // used for buttons (Back, Home, App Switch)
@@ -510,7 +512,7 @@ function androidKeyUp(buttonCode, ws, svmp, isButton) {
         return;
     var buttonRequest = new svmp.Request({type: svmp.Request.RequestType.KEYEVENT, key: buttonRequestArg});
     buttonRequest.key.code = buttonCode;
-    buttonRequest.key.action = 1;
+    buttonRequest.key.action = 1; // KeyEvent.ACTION_UP
 
     // if this is not a button (it's a keyboard key), add any modifiers
     if (!isButton)


### PR DESCRIPTION
Web client will now forward basic hardware keys:
Numbers, letters, symbols, modifiers (shift/ctrl/alt), directional
keys (home/end, page up/down, arrows), and others.
Does NOT forward Windows key, caps/scroll/num lock keys, function
keys, insert, or pause.
Ignores caps lock state (caps only depends upon whether Shift is
pressed).
Also, added a checkbox to temporarily enable soft keys (does not
persist between sessions).
